### PR TITLE
Updated rpmbuild spec file version 0.13

### DIFF
--- a/contrib/rpm/groovyserv.spec
+++ b/contrib/rpm/groovyserv.spec
@@ -1,19 +1,20 @@
 Summary: GroovyServ, a process server for Groovy
 Name: groovyserv
-Version: 0.10
-Release: 0%{?dist}
+Version: 0.13
+Release: 1%{?dist}
 License: Apache License, Version 2.0
 Group: Development/Languages
 Provides: groovyserv
-Requires: java-1.6.0-openjdk
+Requires: java-1.7.0-openjdk
 Requires: groovy >= 1.8.5
-Source0: groovyserv-%{version}-src.zip
+Source0: https://bitbucket.org/kobo/groovyserv-mirror/downloads/%{name}-%{version}-src.zip
 BuildArch: x86_64
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 Packager: Kazuhisa Hara <kazuhisya@gmail.com>
 BuildRequires: groovy >= 1.8.5
 BuildRequires: unzip
-BuildRequires: java-1.6.0-openjdk
+BuildRequires: java-1.7.0-openjdk
+BuildRequires: gcc
 
 %description
 Provides the GroovyServ mechanism for faster groovy execution.
@@ -25,7 +26,6 @@ Group: Development/Languages
 Requires: groovyserv >= %{version}-%{release}
 Requires: ruby
 BuildRequires: ruby
-
 %description ruby
 Provides the GroovyServ mechanism for faster groovy execution.
 
@@ -55,7 +55,6 @@ ln -s /opt/groovyserv/bin/groovyclient.rb $RPM_BUILD_ROOT/usr/local/bin
 #we're not interested in the bat file
 rm $RPM_BUILD_ROOT/opt/groovyserv/bin/groovyserver.bat
 
-
 #required since our sources are in svn
 find $RPM_BUILD_ROOT -name .svn -type d | while read svndir ; do rm -rf $svndir ; done
 
@@ -66,22 +65,21 @@ rm -Rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
-
-/opt/groovyserv/LICENSE.txt
-/opt/groovyserv/NOTICE.txt
-/opt/groovyserv/README.txt
-/opt/groovyserv/bin/groovyserver
-/opt/groovyserv/bin/groovyclient
-/opt/groovyserv/lib
+/opt/groovyserv
+%defattr(755,root,root)
 /usr/local/bin/groovyserver
 /usr/local/bin/groovyclient
 
 %files ruby
 %defattr(-,root,root)
 /opt/groovyserv/bin/groovyclient.rb
+%defattr(755,root,root)
 /usr/local/bin/groovyclient.rb
 
 %changelog
+* Tue Jul 30 2013 Kazuhisa Hara <kazuhisya@gmail.com>
+- Updated to 0.13-release
+
 * Sat Mar 31 2012 Kazuhisa Hara <kazuhisya@gmail.com>
 - Updated to 0.10-release
 - GroovyServ requires Groovy1.8.5+ (https://github.com/kobo/groovyserv/issues/38)


### PR DESCRIPTION
rpm build spec: Updated to 0.13-release
### Change:
- Updated to 0.13-release
### Distro support
- Fedora 19 x86_64
### How to build

```
$ sudo yum install rpm-build groovy unzip java-1.7.0-openjdk gcc ruby
$ rpmdev-setuptree
$ spectool -g -R contrib/rpm/groovyserv.spec
$ rpmbuild --clean -ba contrib/rpm/groovyserv.spec
$ sudo yum install ~/rpmbuild/RPMS/x86_64/groovyserv-0.XX-X.fc19.x86_64.rpm --nogpgcheck
```
### How to use

```
$ /opt/groovyserv/bin/groovyclient -e "println('Hello, GroovyServ.')"
```

or

```
$ export GROOVYSERV_HOME=/opt/groovyserv
$ groovyclient -e "println('Hello, GroovyServ.')"
```
