### PR TITLE
Fix determining current directory in Windows

### DIFF
--- a/src/main/go/common/platform.go
+++ b/src/main/go/common/platform.go
@@ -18,6 +18,7 @@ package common
 import (
 	"os"
 	"runtime"
+	"syscall"
 )
 
 func HomeDir() string {
@@ -25,6 +26,14 @@ func HomeDir() string {
 		return os.Getenv("USERPROFILE")
 	}
 	return os.Getenv("HOME")
+}
+
+func CurrentDir() string {
+	dir, err := syscall.Getwd()
+	if err != nil {
+		return "."
+	}
+	return dir
 }
 
 func ClasspathDelimiter() string {

--- a/src/main/go/server/connected.go
+++ b/src/main/go/server/connected.go
@@ -253,7 +253,7 @@ func (server ConnectedServer) writeInvocationRequest() (err error) {
 	}()
 
 	ew := cmn.NewErrWriter(server.conn)
-	ew.WriteLine("Cwd: " + cmn.Env("PWD", "."))
+	ew.WriteLine("Cwd: " + cmn.CurrentDir())
 	if authToken, err := server.authToken(); err != nil {
 		return err
 	} else {


### PR DESCRIPTION
There is no `PWD` environment variable in Windows. There is a roughly equivalent `CD` variable but it is only available to batch scripts. This patch uses the `syscall` package to determine current directory on any platform, in a portable manner.