### PR TITLE
rpm build spec: Updated to v1.1.0-release

### DIFF
--- a/contrib/rpm/Makefile
+++ b/contrib/rpm/Makefile
@@ -1,10 +1,10 @@
 NAME := groovyserv
-VERSION := $(shell grep Version: $(NAME).spec | cut -d " " -f 2)
+VERSION := $(shell grep Version: $(NAME).spec | tr -s " "| cut -d " " -f 2)
 
 rpm:
 	spectool -g  $(NAME).spec
 	mkdir -p dist/{BUILD,RPMS,SPECS,SOURCES,SRPMS,install}
-	mv $(NAME)-*-src.zip dist/SOURCES/
+	mv v$(VERSION).tar.gz dist/SOURCES/
 	rpmbuild -ba \
 		--define "_topdir $(PWD)/dist" \
 		--define "buildroot $(PWD)/dist/install" \

--- a/contrib/rpm/README.md
+++ b/contrib/rpm/README.md
@@ -1,27 +1,29 @@
 # Contrib Notes
 
-Here you will find unofficial rpmbuild scripts for Red Hat Enterprise Linux and Fedora.
+Here you will find unofficial rpmbuild scripts.
 
 ## Distro support
 
-This version of scripts has so far only been tested on RHEL7, CentOS7 and Fedora20. (probably, work with Oracle Linux7)
+This version of scripts has so far only been tested on Fedora. (probably, work with Red Hat Enterprise Linux 7)
 
-- RHEL7/CentOS7 x86_64
-    - `groovy-2.3.7` package is seen as not provides in Official and 3rd Party repository(EPEL)... Therefore, you'll need to build rpm package of `groovy-2.3.7` before the build of `groovyserv`.
-        - [It might be your: groovy.spec](https://gist.github.com/kazuhisya/1064519)
+- Fedora 25 x86_64
 
+## Compiled Package
 
-    - `golang` package is available through [EPEL](http://fedoraproject.org/wiki/EPEL) repository, and you need enable this repository.
-- Fedora20,21 x86_6 
-    - `groovy-2.3.7` package is seen as not provides in Official and 3rd Party repository(EPEL). Therefore, you'll need to build rpm package of `groovy-2.3.7` before the build of `groovyserv`.
-        - [It might be your: groovy.spec](https://gist.github.com/kazuhisya/1064519)
+- You can find prebuilt rpm binary from here
+    - [FedoraCopr khara/groovyserv Copr](https://copr.fedoraproject.org/coprs/khara/groovyserv/)
+
+```bash
+$ sudo dnf copr enable khara/groovyserv
+$ sudo dnf install -y groovyserv
+```
 
 ## Building rpm Package (example)
 
 settin up:
 
 ```bash
-$ sudo yum install -y yum-utils rpmdevtools make
+$ sudo dnf install -y dnf-plugins-core rpmdevtools make
 ```
 
 git clone and make:
@@ -29,12 +31,12 @@ git clone and make:
 ```bash
 $ git clone https://github.com/kobo/groovyserv.git
 $ cd groovyserv/contrib/rpm/
-$ sudo yum-builddep ./groovyserv.spec
+$ sudo dnf builddep -y ./groovyserv.spec
 $ make rpm
 ```
 
 install package:
 
 ```bash
-$ sudo yum install ./dist/RPMS/x86_64/groovyserv-*.el7.x86_64.rpm
+$ sudo dnf install ./dist/RPMS/x86_64/groovyserv-*.x86_64.rpm
 ```

--- a/contrib/rpm/groovyserv.spec
+++ b/contrib/rpm/groovyserv.spec
@@ -1,42 +1,39 @@
-Summary: GroovyServ, a process server for Groovy
-Name: groovyserv
-Version: 1.0.0
-Release: 1%{?dist}
-License: Apache License, Version 2.0
-Group: Development/Languages
-Provides: groovyserv
-Requires: java >= 1.7
-Requires: groovy >= 2.3.7
-Source0: https://bitbucket.org/kobo/groovyserv-mirror/downloads/%{name}-%{version}-src.zip
-BuildRoot: %{_tmppath}/%{name}-%{version}-root
-Packager: Kazuhisa Hara <kazuhisya@gmail.com>
+%define debug_package %{nil}
+
+Summary:       GroovyServ, a process server for Groovy
+Name:          groovyserv
+Version:       1.1.0
+Release:       1%{?dist}
+License:       Apache License, Version 2.0
+Group:         Development/Languages
+Requires:      java >= 1.8
+Requires:      groovy >= 2.3.7
+Source0:       https://github.com/kobo/%{name}/archive/v%{version}.tar.gz
+BuildRoot:     %{_tmppath}/%{name}-%{version}-root
+Packager:      Kazuhisa Hara <kazuhisya@gmail.com>
 BuildRequires: groovy >= 2.3.7
 BuildRequires: golang >= 1.3
-BuildRequires: java >= 1.7
+BuildRequires: java >= 1.8
+BuildRequires: java-devel >= 1.8
 
 %description
 Provides the GroovyServ mechanism for faster groovy execution.
 
 %prep
-rm %{_sourcedir}/groovyserv-%{version}*bin.zip -rf
-rm %{_sourcedir}/groovyserv-%{version} -rf
+%setup -q -n %{name}-%{version}
 
 %build
-cd %{_sourcedir}
-unzip groovyserv-%{version}-src.zip
-cd groovyserv-%{version}
 export _JAVA_OPTIONS=-Dfile.encoding=UTF-8
 ./gradlew clean distLocalBin
-cd %{_sourcedir}
-mv groovyserv-%{version}/build/distributions/groovyserv-%{version}-bin-local.zip .
-rm groovyserv-%{version} -rf
-unzip groovyserv-%{version}-bin-local.zip
+mv build/distributions/%{name}-%{version}-bin-local.zip ../
+cd ../ && rm -rf %{name}-%{version}
+unzip %{name}-%{version}-bin-local.zip
 
 %install
 mkdir -p $RPM_BUILD_ROOT/opt $RPM_BUILD_ROOT/usr/bin
-cp -Rp %{_sourcedir}/groovyserv-%{version} $RPM_BUILD_ROOT/opt/groovyserv
+cp -Rp $RPM_BUILD_DIR/%{name}-%{version} $RPM_BUILD_ROOT/opt/%{name}
 for file in groovyserver groovyclient ; do
-  ln -s /opt/groovyserv/bin/$file $RPM_BUILD_ROOT/usr/bin
+  ln -s /opt/%{name}/bin/$file $RPM_BUILD_ROOT/usr/bin
 done
 
 %clean
@@ -52,7 +49,13 @@ rm -Rf $RPM_BUILD_ROOT
 /usr/bin/groovyclient
 
 %changelog
-* Thu Nov  6 2014 Kazuhisa Hara <kazuhisya@gmail.com>
+* Thu Dec  8 2016 Kazuhisa Hara <kazuhisya@gmail.com> - 1.1.0-1
+- Updated to 1.1.0-release
+- Update source zip to tar.gz version
+- Fixed to pass the test  for rpmlint
+- Added prebuilt rpm link from Fedora Copr
+
+* Thu Nov  6 2014 Kazuhisa Hara <kazuhisya@gmail.com> - 1.0.0-1
 - Updated to 1.0.0-release
 - Commands written in Ruby is removed
 - [rpm] Added golang in BuildRequires


### PR DESCRIPTION
I got late, but I created rpm build spec for v1.1.0
and prepared rpm repository using Fedora Copr Project.
You can find prebuilt rpm binary from here.
    - [FedoraCopr khara/groovyserv Copr](https://copr.fedoraproject.org/coprs/khara/groovyserv/)

- Updated to 1.1.0-release
- Update source zip to tar.gz version
- Fixed to pass the test  for rpmlint
- Added prebuilt rpm link from Fedora Copr