### PR TITLE
add option to allow change of security manager

### DIFF
--- a/src/main/go/server/server.go
+++ b/src/main/go/server/server.go
@@ -287,7 +287,9 @@ func (server Server) startInBackground() (err error) {
 		" -Djava.awt.headless=true" +
 		// gy-like parameters (experimental)
 		// http://bbook.hatenablog.jp/entry/2015/03/09/205354
-		" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+		" -XX:+TieredCompilation -XX:TieredStopAtLevel=1" +
+	        // Without this GroovServer can not start on JDK above then Java 17.
+	        " -Djava.security.manager=allow"
 
 	// Preparing a command
 	groovyServOpts := cmn.Env("GROOVYSERV_OPTS", "")


### PR DESCRIPTION
After Java 18 we need to specifically allow to change the SecurityManager.

See more: https://openjdk.org/jeps/411

connected to: #90 GroovyServ not working on JDK 21 and Groovy 4 https://github.com/kobo/groovyserv/issues/90

