### PR TITLE
Upgrade JNA #93

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-FROM golang:1.9.4-stretch
+FROM debian:bookworm
 
-ENV JAVA_VERSION 8u161-oracle
+ENV JAVA_VERSION 8.0.452-tem
 ENV GROOVY_VERSION 2.4.14
 ENV GOLANG_VERSION 1.9.4
 
 # Prepare environment
 ENV JAVA_HOME /opt/java
-ENV PATH $PATH:$JAVA_HOME/bin
+ENV PATH $PATH:/usr/local/go/bin:$JAVA_HOME/bin
 
 # SDKMAN: Java / Groovy
-RUN apt-get update && apt-get install -y --no-install-recommends curl unzip zip && \
-    curl -s "https://get.sdkman.io" | bash && \
-    /bin/bash -lc "sdk install java $JAVA_VERSION" && \
-    /bin/bash -lc "sdk install groovy $GROOVY_VERSION"
+RUN apt-get update && apt-get install -y curl unzip zip wget
+RUN curl -s "https://get.sdkman.io" | bash 
+RUN /bin/bash -lc "sdk install java $JAVA_VERSION" 
+RUN /bin/bash -lc "sdk install groovy $GROOVY_VERSION"
+RUN /bin/bash -lc "wget -O go.tar.gz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"
+RUN /bin/bash -lc "tar -C /usr/local -xzf go.tar.gz"
+
 ENV JAVA_HOME /root/.sdkman/candidates/java/current
 ENV GROOVY_HOME /root/.sdkman/candidates/groovy/current
-ENV PATH $PATH:$GROOVY_HOME/bin:$JAVA_HOME/bin
+ENV GO_HOME /usr/local/go
+ENV PATH $PATH:$GROOVY_HOME/bin:$JAVA_HOME/bin:$GO_HOME/bin
 
 WORKDIR /usr/src/app
 CMD ["./gradlew"]

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ apply plugin: "io.sdkman.vendors"
 defaultTasks 'clean', 'check', 'dist' // whole tasks
 
 // keep same as groovy-core
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenLocal()
@@ -45,7 +45,7 @@ configurations {
 dependencies {
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile 'commons-cli:commons-cli:1.3.1'
-    archives 'net.java.dev.jna:jna:4.2.2'
+    archives 'net.java.dev.jna:jna:5.17.0'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testRuntime 'cglib:cglib-nodep:3.1'       // for spock: enables mocking of classes (in addition to interfaces)
     testRuntime 'org.objenesis:objenesis:2.1' // for spock: enables mocking of without default constructor (together with CGLIB)


### PR DESCRIPTION
this solves #93, but I also had to increase target JVM to 1.8, because JNA 5 requires at least Java 8.

After that the build environment had to be upgraded as "stretch" could not install curl and such any more. (I think repositories are shut down.)

For a more complete upgrade I am coming back later.